### PR TITLE
alex/escape after rendering

### DIFF
--- a/test/golden/file-package-escaping.output.yaml
+++ b/test/golden/file-package-escaping.output.yaml
@@ -1,0 +1,12 @@
+capture: |-
+  Just
+    FlatfileCapture
+      { fileAbsoluteUrl =
+          Just "https://output.com/some-nice-path/very-nice/really%2Bnice"
+      , fileVariables =
+          fromList [ ( "path" , "some-nice-path/very-nice/really+nice" ) ]
+      , filePackage = "21c24cd1-73fa-4970-8a6a-bc570e55b91e"
+      }
+headers:
+  Location: https://output.com/some-nice-path/very-nice/really%2Bnice
+status: 302

--- a/test/golden/file-package-escaping.yaml
+++ b/test/golden/file-package-escaping.yaml
@@ -1,0 +1,11 @@
+# multiple variables
+path: "/some-nice-path/very-nice/really+nice"
+headers:
+  Host: nicedomain.com
+manifest:
+  rules:
+    - type: file-v1
+      incoming-path: "/{+path}"
+      domain: nicedomain.com
+      package-id: 21c24cd1-73fa-4970-8a6a-bc570e55b91e
+      outgoing-url: https://output.com/{+path}


### PR DESCRIPTION
- nub the query parameters (keep the first occurrence)
- Escape reserved characters in URI path after rendering
