### PR TITLE
proxy request when basic auth is present

### DIFF
--- a/src/Scarf/Gateway/Rule/Docker.hs
+++ b/src/Scarf/Gateway/Rule/Docker.hs
@@ -151,6 +151,10 @@ redirectOrProxy request domain alwaysProxy !capture ResponseBuilder {..}
   | alwaysProxy =
       -- Proxy request unconditionally
       proxyTo (const capture) domain
+  -- when a basic authorization header is present, it will be proxied
+  | Just authHeader <- lookup "Authorization" (Wai.requestHeaders request),
+    "Basic" `ByteString.isPrefixOf` authHeader =
+      proxyTo (const capture) domain
   | shouldRedirectDockerRequest request =
       -- As with the Host header we have to respect the proxy protocol
       -- when redirecting.

--- a/test/golden/docker-basic-auth.output.yaml
+++ b/test/golden/docker-basic-auth.output.yaml
@@ -1,0 +1,14 @@
+capture: |-
+  Just
+    DockerCapture
+      { dockerCaptureImage = [ "library" , "enterprise" ]
+      , dockerCaptureReference = "latest"
+      , dockerCaptureBackendRegistry = "ghcr.io"
+      , dockerCapturePackage =
+          Just "d7e7f172-67af-4b5b-ba6d-c9eab0903b0c"
+      , dockerCaptureAutoCreate = Nothing
+      }
+headers:
+  Location: https://ghcr.io/v2/library/enterprise/manifests/latest
+  X-This-Request-Was-Proxied: '1'
+status: 307

--- a/test/golden/docker-basic-auth.yaml
+++ b/test/golden/docker-basic-auth.yaml
@@ -1,0 +1,12 @@
+path: /v2/library/enterprise/manifests/latest
+headers:
+  Host: mariadb.com
+  Authorization: Basic ZGVtbzpwQDU1dzByZA==
+manifest:
+  rules:
+    - type:  docker-v1
+      repository-name: library/enterprise
+      domain: mariadb.com
+      registry: ghcr.io
+      package-id: "d7e7f172-67af-4b5b-ba6d-c9eab0903b0c"
+


### PR DESCRIPTION
This PR adds a case for for checking if the request has a basic token in the authorization header. When it finds a basic token, it will proxy the request.