### PR TITLE
Change redirect from 302 to 307

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Freeze
       run: |
         cabal freeze
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4.2.4
       name: Cache ~/.cabal/store
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}

--- a/src/Scarf/Gateway.hs
+++ b/src/Scarf/Gateway.hs
@@ -38,8 +38,8 @@ import Network.HTTP.Client (Manager)
 import Network.HTTP.Client qualified as HC
 import Network.HTTP.Types
   ( Status,
-    found302,
     hLocation,
+    temporaryRedirect307,
     methodNotAllowed405,
     notFound404,
     notModified304,
@@ -159,7 +159,7 @@ gateway tracer GatewayConfig {..} = do
             respondOk tracer span request respond
           RedirectTo capture absoluteUrl ->
             redirectTo tracer span absoluteUrl request respond
-              `finally` gatewayReportRequest span request found302 [capture]
+              `finally` gatewayReportRequest span request temporaryRedirect307 [capture]
           ProxyTo mkCapture domain ->
             let (targetDomain, shouldUseTLS) = gatewayModifyProxyDomain domain
              in gatewayProxyTo
@@ -268,7 +268,7 @@ redirectTo ::
 redirectTo tracer span absoluteUrl = \_ respond ->
   traced_ tracer (spanOpts "redirect-to" (childOf span)) $ \span -> do
     addTag span ("redirect-to", StringT (Text.decodeUtf8 absoluteUrl))
-    respond (responseLBS found302 [(hLocation, absoluteUrl)] mempty)
+    respond (responseLBS temporaryRedirect307 [(hLocation, absoluteUrl)] mempty)
 
 respondBytes ::
   Tracer ->

--- a/test/Scarf/Gateway/Test.hs
+++ b/test/Scarf/Gateway/Test.hs
@@ -208,7 +208,7 @@ gatewayProxyTestCase name toConfig session = do
 
 assertRedirect :: (HasCallStack) => ByteString -> SResponse -> Session ()
 assertRedirect location response = do
-  assertStatus 302 response
+  assertStatus 307 response
   assertHeader "Location" location response
 
 -- | We add a X-Scarf-Proxy-To header to witness that a request got proxied.

--- a/test/golden/catch-all-1.output.yaml
+++ b/test/golden/catch-all-1.output.yaml
@@ -8,4 +8,4 @@ captures: |-
   ]
 headers:
   Location: https://downloads.test.sh/hello%20world
-status: 302
+status: 307

--- a/test/golden/catch-all-2.output.yaml
+++ b/test/golden/catch-all-2.output.yaml
@@ -10,4 +10,4 @@ captures: |-
 headers:
   Location: https://downloads.test.sh/search?q=hello%20world
 query: ?q=hello%20world
-status: 302
+status: 307

--- a/test/golden/file-package-escaping-1.output.yaml
+++ b/test/golden/file-package-escaping-1.output.yaml
@@ -10,4 +10,4 @@ captures: |-
   ]
 headers:
   Location: https://output.com/some-nice-path/very-nice/really+nice
-status: 302
+status: 307

--- a/test/golden/file-package-escaping.output.yaml
+++ b/test/golden/file-package-escaping.output.yaml
@@ -8,4 +8,4 @@ captures: |-
   ]
 headers:
   Location: https://output.com/really%2Bnice
-status: 302
+status: 307

--- a/test/golden/file-package-with-variables-1.output.yaml
+++ b/test/golden/file-package-with-variables-1.output.yaml
@@ -13,4 +13,4 @@ captures: |-
 headers:
   Location: https://datausa.io/api/data?drilldowns=Nation&measures=Population
 query: ?drilldowns=Nation&measures=Population
-status: 302
+status: 307

--- a/test/golden/file-package-with-variables-2.output.yaml
+++ b/test/golden/file-package-with-variables-2.output.yaml
@@ -13,4 +13,4 @@ captures: |-
 headers:
   Location: https://datausa.io/api/data?drilldowns=Nation&measures=Population
 query: ?measures=Population
-status: 302
+status: 307

--- a/test/golden/file-package-with-variables-4.output.yaml
+++ b/test/golden/file-package-with-variables-4.output.yaml
@@ -8,4 +8,4 @@ captures: |-
   ]
 headers:
   Location: https://datausa.io/api/data
-status: 302
+status: 307

--- a/test/golden/file-package-without-variable-2.output.yaml
+++ b/test/golden/file-package-without-variable-2.output.yaml
@@ -11,4 +11,4 @@ captures: |-
 headers:
   Location: https://datausa.io/api/data?drilldowns=Nation&measures=Population
 query: ?drilldowns=Nation&measures=Population
-status: 302
+status: 307

--- a/test/golden/file-package-without-variable.output.yaml
+++ b/test/golden/file-package-without-variable.output.yaml
@@ -11,4 +11,4 @@ captures: |-
 headers:
   Location: https://datausa.io/api/data?drilldowns=Nation&measures=Population
 query: ?drilldowns=Nation&measures=Population
-status: 302
+status: 307

--- a/test/golden/file-package-without-varible-1.output.yaml
+++ b/test/golden/file-package-without-varible-1.output.yaml
@@ -11,4 +11,4 @@ captures: |-
 headers:
   Location: https://datausa.io/api/data?drilldowns=Nation&measures=Population
 query: ?drilldowns=Nation&measures=Population
-status: 302
+status: 307

--- a/test/golden/file-package-without-varible-2.output.yaml
+++ b/test/golden/file-package-without-varible-2.output.yaml
@@ -11,4 +11,4 @@ captures: |-
 headers:
   Location: https://datausa.io/api/data?drilldowns=Nation&measures=Population
 query: ?drilldowns=Nation&measures=Population
-status: 302
+status: 307

--- a/test/golden/file-package-without-varible-3.output.yaml
+++ b/test/golden/file-package-without-varible-3.output.yaml
@@ -10,4 +10,4 @@ captures: |-
   ]
 headers:
   Location: https://datausa.io/api/data?drilldowns=Nation&measures=Population
-status: 302
+status: 307

--- a/test/golden/file-package-without-varible-4.output.yaml
+++ b/test/golden/file-package-without-varible-4.output.yaml
@@ -8,4 +8,4 @@ captures: |-
   ]
 headers:
   Location: https://datausa.io/api/data
-status: 302
+status: 307

--- a/test/golden/issue-2024-02-06.output.yaml
+++ b/test/golden/issue-2024-02-06.output.yaml
@@ -9,4 +9,4 @@ captures: |-
 headers:
   Location: https://some.host/blah/blah?prefix=foo
 query: ?prefix=foo
-status: 302
+status: 307

--- a/test/golden/issue-2535-1.output.yaml
+++ b/test/golden/issue-2535-1.output.yaml
@@ -8,4 +8,4 @@ captures: |-
   ]
 headers:
   Location: https://some.engineering/blah/blah
-status: 302
+status: 307

--- a/test/golden/python-test-file.output.yaml
+++ b/test/golden/python-test-file.output.yaml
@@ -11,4 +11,4 @@ captures: |-
   ]
 headers:
   Location: https://files.pythonhosted.org/packages/ab/67/19e93e3f8c3e077dcf6fc54e84e1cff609c4a7e0a3ce14f70794dde60063/numpy-1.3.0.tar.gz#sha256=7524687cce85aa78103046db5e617c626b0ef871a203a049159f88f35647c90d
-status: 302
+status: 307

--- a/test/golden/re-file-package-test-1.output.yaml
+++ b/test/golden/re-file-package-test-1.output.yaml
@@ -8,4 +8,4 @@ captures: |-
   ]
 headers:
   Location: https://datausa.io/api/data
-status: 302
+status: 307

--- a/test/golden/re-file-package-test-2.output.yaml
+++ b/test/golden/re-file-package-test-2.output.yaml
@@ -13,4 +13,4 @@ captures: |-
   ]
 headers:
   Location: https://datausa.io/some-example-package/0.1.2.4-head
-status: 302
+status: 307


### PR DESCRIPTION
This PR changes the default redirect mechanism to use 307 instead of 302. 307 makes HTTP clients send the original request body to the redirect target.