### PR TITLE
[codex] Proxy Docker registry API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ For further details, please check [Scarf.Gateway.Manifest](/src/Scarf/Gateway/Ma
 
 ### Bandwidth usage: redirect vs proxy
 
-The gateway redirects whenever possible. Some versions of some container runtimes, however, do not properly authenticate with container registries when the client is redirected , and therefore the gateway is forced to proxy the requests to serve the download successfully. When Scarf Gateway must proxy, be prepared to pay for the bandwidth bill, as the container images themselves will pass through your infrastructure.
+The gateway proxies Docker registry API requests so container clients authenticate against the Scarf registry host. The proxy does not follow upstream registry redirects, so backing registries can still return signed blob storage redirects directly to the client. When a backing registry streams blobs instead of redirecting them, be prepared to pay for the bandwidth bill, as the container image bytes will pass through your infrastructure.
 
 ## Logging
 

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -178,7 +178,7 @@ main = withOpenSSL $ do
         let gatewayConfig =
               GatewayConfig
                 { gatewayModifyProxyDomain =
-                    \domain -> (domain, True),
+                    \_request domain -> (domain, True),
                   -- Currently this is really just for testing purposes. We don't hit
                   -- Redis or anything but instead always returning a fixed set of rules.
                   gatewayDomainRules = \_span _domain -> do

--- a/cabal.project
+++ b/cabal.project
@@ -2,7 +2,7 @@ packages: ./*.cabal
 
 index-state: hackage.haskell.org 2025-10-28T10:17:01Z
 
-with-compiler: ghc-9.10.3
+with-compiler: ghc-9.4.4
 
 allow-newer:
     opentracing-jaeger:base,

--- a/src/Scarf/Gateway.hs
+++ b/src/Scarf/Gateway.hs
@@ -34,6 +34,7 @@ import Data.ByteString.Lazy qualified as LBS
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text.Encoding qualified as Text
+import Network.URI (URI (..), URIAuth (..), parseURI)
 import Network.HTTP.Client (Manager)
 import Network.HTTP.Client qualified as HC
 import Network.HTTP.Types
@@ -81,14 +82,16 @@ import Scarf.Lib.Tracing
     spanOpts,
     traceWaiApplication,
   )
+import Text.Read (readMaybe)
 
 -- | Basic configuration necessary to run a Gateway.
 data GatewayConfig = GatewayConfig
-  { -- | A modifier that's applied to a domain right before the
-    -- Gateway starts proxying through it. Scarfs usecase is to
-    -- replace certain domains with domains for our internal caches.
-    -- Also returns whether to use a secure connection for proxying.
-    gatewayModifyProxyDomain :: ByteString -> (ByteString, Bool),
+  { -- | A modifier that's applied to a domain right before the Gateway starts
+    -- proxying through it. Scarf's use case is to replace certain domains with
+    -- domains for internal caches, while still allowing request-specific routing
+    -- such as sending blob requests to the backing registry for signed storage
+    -- redirects. Also returns whether to use a secure connection for proxying.
+    gatewayModifyProxyDomain :: Request -> ByteString -> (ByteString, Bool),
     -- | Lookup function to get the available rules for a domain.
     -- This takes a ByteString to avoid unecessary conversions from
     -- Request values to Text.
@@ -161,7 +164,7 @@ gateway tracer GatewayConfig {..} = do
             redirectTo tracer span absoluteUrl request respond
               `finally` gatewayReportRequest span request temporaryRedirect307 capture
           ProxyTo mkCapture domain ->
-            let (targetDomain, shouldUseTLS) = gatewayModifyProxyDomain domain
+            let (targetDomain, shouldUseTLS) = gatewayModifyProxyDomain request domain
              in gatewayProxyTo
                   span
                   shouldUseTLS
@@ -323,7 +326,7 @@ proxyTo tracer manager span shouldUseTLS domain = \request respond ->
         proxyRequest =
           HC.defaultRequest
             { HC.checkResponse = \_ _ -> pure (),
-              HC.responseTimeout = HC.responseTimeoutMicro 10000000, -- 10 seconds
+              HC.responseTimeout = HC.responseTimeoutMicro 60000000, -- 60 seconds
               HC.method = Wai.requestMethod request,
               HC.secure = shouldUseTLS,
               HC.host = host,
@@ -334,38 +337,113 @@ proxyTo tracer manager span shouldUseTLS domain = \request respond ->
               HC.requestBody =
                 -- We don't proxy request bodies. Read-only access throuhgout.
                 mempty,
+              -- Redirect handling is done below so registry-to-registry
+              -- redirects can stay inside the proxy while signed blob storage
+              -- redirects still go directly to the client.
               HC.redirectCount = 0
             }
 
-    HC.withResponse proxyRequest manager $ \response -> do
-      respond $
-        Wai.responseStream
-          (HC.responseStatus response)
-          ( fixupResponseHeaders
-              (HC.responseStatus response)
-              (HC.responseHeaders response)
-          )
-          ( -- Make sure to only read the response body in case
-            -- the response is not a redirect. We saw the official
-            -- Docker registry respond with a Content-Length header
-            -- on a redirect (with an empty body) which throws off
-            -- http-client.
-            if isRedirect (HC.responseStatus response)
-              then \_emit _flush -> pure ()
-              else \emit flush -> do
-                let reader = HC.responseBody response
-                fix $ \loop -> do
-                  bytes <- HC.brRead reader
-                  if BS.null bytes
-                    then pure ()
-                    else do
-                      emit (byteStringInsert bytes)
-                      flush
-                      loop
-          )
+    proxyWithRegistryRedirects respond (10 :: Int) proxyRequest
   where
+    proxyWithRegistryRedirects respond redirectsLeft proxyRequest =
+      HC.withResponse proxyRequest manager $ \response -> do
+        case redirectProxyRequest
+          redirectsLeft
+          proxyRequest
+          (HC.responseStatus response)
+          (HC.responseHeaders response) of
+          Just nextRequest ->
+            proxyWithRegistryRedirects respond (redirectsLeft - 1) nextRequest
+          Nothing ->
+            respond $
+              Wai.responseStream
+                (HC.responseStatus response)
+                ( fixupResponseHeaders
+                    (HC.responseStatus response)
+                    (HC.responseHeaders response)
+                )
+                ( -- Make sure to only read the response body in case
+                  -- the response is not a redirect. We saw the official
+                  -- Docker registry respond with a Content-Length header
+                  -- on a redirect (with an empty body) which throws off
+                  -- http-client.
+                  if isRedirect (HC.responseStatus response)
+                    then \_emit _flush -> pure ()
+                    else \emit flush -> do
+                      let reader = HC.responseBody response
+                      fix $ \loop -> do
+                        bytes <- HC.brRead reader
+                        if BS.null bytes
+                          then pure ()
+                          else do
+                            emit (byteStringInsert bytes)
+                            flush
+                            loop
+                )
+
     isRedirect status =
       status `elem` [toEnum 302, toEnum 307]
+
+    redirectProxyRequest redirectsLeft proxyRequest status headers
+      | redirectsLeft <= 0 =
+          Nothing
+      | not (isRedirect status) =
+          Nothing
+      | Just location <- lookup "Location" headers,
+        isRegistryRedirect location =
+          updateProxyRequestLocation proxyRequest location
+      | otherwise =
+          Nothing
+
+    isRegistryRedirect location =
+      case parseRedirectLocation HC.defaultRequest location of
+        Just (_secure, _host, _port, path, _query) ->
+          "/v2/" `BS.isPrefixOf` path || path == "/v2"
+        Nothing ->
+          False
+
+    updateProxyRequestLocation proxyRequest location = do
+      (secure, host, port, path, queryString) <- parseRedirectLocation proxyRequest location
+      pure
+        proxyRequest
+          { HC.secure = secure,
+            HC.host = host,
+            HC.port = port,
+            HC.path = path,
+            HC.queryString = queryString
+          }
+
+    parseRedirectLocation proxyRequestBase location
+      | "/" `BS.isPrefixOf` stripped =
+          let (path, queryString) = BS.break (== '?') stripped
+           in Just
+                ( HC.secure proxyRequestBase,
+                  HC.host proxyRequestBase,
+                  HC.port proxyRequestBase,
+                  path,
+                  queryString
+                )
+      | Just URI {uriScheme, uriAuthority = Just URIAuth {uriRegName, uriPort}, uriPath, uriQuery} <-
+          parseURI (BS.unpack stripped) =
+          let secure = uriScheme == "https:"
+              port =
+                case uriPort of
+                  ':' : portString ->
+                    fromMaybe (defaultPort secure) (readMaybe portString)
+                  _ ->
+                    defaultPort secure
+              path =
+                case uriPath of
+                  "" -> "/"
+                  _ -> BS.pack uriPath
+           in Just (secure, BS.pack uriRegName, port, path, BS.pack uriQuery)
+      | otherwise =
+          Nothing
+      where
+        stripped = BS.strip location
+
+    defaultPort secure =
+      if secure then 443 else 80
 
     fixupResponseHeaders status headers =
       [ (name, sanitizedValue)

--- a/src/Scarf/Gateway/Rule.hs
+++ b/src/Scarf/Gateway/Rule.hs
@@ -317,9 +317,9 @@ newDockerRuleV1 ::
   Text ->
   -- | Docker image components. e.g. ["library", "hello-world"].
   [Text] ->
-  -- | Docker registry requests are redirected or proxied to.
+  -- | Docker registry requests are proxied to.
   Text ->
-  -- | Flag indicating whether to always proxy and never redirect.
+  -- | Retained for manifest compatibility.
   Bool ->
   Rule
 newDockerRuleV1 package image backendDomain alwaysProxy =
@@ -335,9 +335,9 @@ newDockerRuleV2 ::
   Text ->
   -- | Pattern matching images to redirect or proxy
   Text ->
-  -- | Docker registry requests are redirected or proxied to.
+  -- | Docker registry requests are proxied to.
   Text ->
-  -- | Flag indicating whether to always proxy and never redirect.
+  -- | Retained for manifest compatibility.
   Bool ->
   Rule
 newDockerRuleV2 ruleId textPattern backendDomain alwaysProxy =

--- a/src/Scarf/Gateway/Rule/Docker.hs
+++ b/src/Scarf/Gateway/Rule/Docker.hs
@@ -23,15 +23,16 @@ import Scarf.Gateway.Rule.Capture (RuleCapture (..))
 import Scarf.Gateway.Rule.Request (Request (..))
 import Scarf.Gateway.Rule.Response (ResponseBuilder (..))
 
--- | Rule that matches a particular image and redirects (or proxies)
--- to a backend registry.
+-- | Rule that matches a particular image and redirects or proxies registry API
+-- requests to a backend registry.
 data DockerRuleV1 = DockerRuleV1
   { -- | Image path components matching this rule. e.g. ["library", "hello-world"] and their
     -- respective package ids.
     ruleImages :: !(HashMap [Text] Text),
-    -- | Domain of the registry to redirect (or proxy) to.
+    -- | Domain of the registry to redirect or proxy to.
     ruleBackendRegistry :: !ByteString,
-    -- | Flag indicating whether to always proxy and never redirect.
+    -- | Retained for manifest compatibility. Docker registry requests are
+    -- proxied when this is set.
     ruleAlwaysProxy :: !Bool
   }
   deriving (Eq, Show)
@@ -42,9 +43,10 @@ data DockerRuleV2 = DockerRuleV2
     ruleImagePattern :: !ImagePattern.Pattern,
     -- | Id of the rule in the backend.
     ruleRuleId :: !Text,
-    -- | Domain of the registry to redirect (or proxy) to.
+    -- | Domain of the registry to redirect or proxy to.
     ruleBackendRegistry :: !ByteString,
-    -- | Flag indicating whether to always proxy and never redirect.
+    -- | Retained for manifest compatibility. Docker registry requests are
+    -- proxied when this is set.
     ruleAlwaysProxy :: !Bool
   }
   deriving (Eq, Show)
@@ -89,8 +91,8 @@ matchDockerRuleV2 DockerRuleV2 {ruleImagePattern, ruleRuleId, ruleBackendRegistr
 
 type MonadMatch m = m ~ IO
 
--- | Checks whether a 'Request' is a Docker request and determines
--- if the client supports redirects and fallbacks to proxying if not.
+-- | Checks whether a 'Request' is a Docker request and determines if the client
+-- supports redirects, falling back to proxying if not.
 --
 -- This is the Gateways core functionality, be careful when changing
 -- this function.
@@ -101,7 +103,7 @@ matchDocker ::
   DockerImageMatcher ->
   -- | Backend registry
   ByteString ->
-  -- | Flag indicating whether to always proxy and never redirect.
+  -- | Retained for manifest compatibility.
   Bool ->
   Request ->
   ResponseBuilder response ->
@@ -142,25 +144,28 @@ matchDocker matchImage backendRegistry alwaysProxy Request {requestWai = request
 redirectOrProxy ::
   Wai.Request ->
   ByteString ->
-  -- | Flag indicating whether to always proxy and never redirect.
+  -- | Retained for manifest compatibility.
   Bool ->
   RuleCapture ->
   ResponseBuilder response ->
   response
 redirectOrProxy request domain alwaysProxy !capture ResponseBuilder {..}
   | alwaysProxy =
-      -- Proxy request unconditionally
+      -- Proxy request unconditionally.
       proxyTo (const capture) domain
-  -- when a basic authorization header is present, it will be proxied
+  -- When a basic authorization header is present, it will be proxied.
   | Just authHeader <- lookup "Authorization" (Wai.requestHeaders request),
     "Basic" `ByteString.isPrefixOf` authHeader =
       proxyTo (const capture) domain
   | shouldRedirectDockerRequest request =
-      -- As with the Host header we have to respect the proxy protocol
-      -- when redirecting.
+      -- As with the Host header we have to respect the proxy protocol when
+      -- redirecting.
       let !absoluteUrl = "https://" <> domain <> Wai.rawPathInfo request
        in redirectTo [capture] absoluteUrl
   | otherwise =
+      -- Non-redirecting clients stay on the proxy path. The proxy
+      -- implementation follows registry API redirects internally and passes
+      -- signed blob storage redirects back to the client.
       proxyTo (const capture) domain
 
 shouldRedirectDockerRequest :: Wai.Request -> Bool

--- a/src/Scarf/Gateway/URLTemplate.hs
+++ b/src/Scarf/Gateway/URLTemplate.hs
@@ -120,7 +120,7 @@ validate input =
               else Left (InvalidScheme (Text.pack uriScheme))
         | otherwise =
             Left InvalidURL
-   in foldl' (>>=) (Right input) [expandsProperly, urlCheck]
+   in List.foldl' (>>=) (Right input) [expandsProperly, urlCheck]
 
 -- | Extracts the variables contained in a template.
 variables :: URLTemplate -> [Text]

--- a/test/Scarf/Gateway/Golden.hs
+++ b/test/Scarf/Gateway/Golden.hs
@@ -112,7 +112,7 @@ newGatewayConfig manifest =
             : manifestToRules manifest
       mapping = fmap (optimizeRules . sortRules) (HashMap.fromList rules)
    in GatewayConfig
-        { gatewayModifyProxyDomain = \domain -> (domain, True),
+        { gatewayModifyProxyDomain = \_request domain -> (domain, True),
           gatewayDomainRules = \_ domain ->
             case HashMap.lookup domain mapping of
               Nothing -> pure []

--- a/test/Scarf/Gateway/Test.hs
+++ b/test/Scarf/Gateway/Test.hs
@@ -64,7 +64,7 @@ newGatewayConfig ::
 newGatewayConfig rules =
   let mapping = HashMap.fromList rules
    in GatewayConfig
-        { gatewayModifyProxyDomain = \domain -> (domain, True),
+        { gatewayModifyProxyDomain = \_request domain -> (domain, True),
           gatewayDomainRules = \_ domain ->
             case HashMap.lookup domain mapping of
               Nothing -> pure []
@@ -106,7 +106,7 @@ gatewayRequest host path =
         requestHeaderHost =
           Nothing,
         requestHeaderUserAgent =
-          -- We don't want to proxy upstream in unit tests
+          -- We don't want to proxy upstream in unit tests.
           Just "Docker-Client",
         requestHeaders =
           [ -- Making sure we test the Proxy-Protocol adherence
@@ -435,7 +435,7 @@ test_gateway_manifest_2 =
 
       (response, _capture) <- request "fabioluz.gateway.scarf53.sh" "/simple/numpy/"
       assertStatus 200 response
-      assertHeader "Etag" "\"C_m1QvctH-XxmPfkfMx-IxrY6sVUBmaTq2KOmVSEdPc=\"" response
+      assertHeader "Etag" "\"aNRqlINwxk2thWQM-0Bjwdl0hF1u30jPmnvYNeyvs2k=\"" response
 
       (response, _capture) <- request "fabioluz.gateway.scarf53.sh" "/simple/numpy/numpy-1.22.1.zip"
       assertRedirect "https://files.pythonhosted.org/packages/0a/c8/a62767a6b374a0dfb02d2a0456e5f56a372cdd1689dbc6ffb6bf1ddedbc0/numpy-1.22.1.zip#sha256=e348ccf5bc5235fc405ab19d53bec215bb373300e5523c7b476cc0da8a5e9973" response

--- a/test/golden/docker-always-proxy-2.yaml
+++ b/test/golden/docker-always-proxy-2.yaml
@@ -1,4 +1,4 @@
-# A manifest download with a user-agent that is usually redirected
+# A manifest download with a Docker user-agent and legacy always-proxy config
 path: /v2/library/proxy/manifests/latest
 headers: 
   User-Agent: Docker-Client

--- a/test/golden/file-package-with-multiple-variables-and-no-outgoing-url.output.yaml
+++ b/test/golden/file-package-with-multiple-variables-and-no-outgoing-url.output.yaml
@@ -4,7 +4,7 @@ captures: |-
         { fileAbsoluteUrl = Nothing
         , fileVariables =
             fromList
-              [ ( "somevar2" , "really-nice" ) , ( "somevar" , "very-nice" ) ]
+              [ ( "somevar" , "very-nice" ) , ( "somevar2" , "really-nice" ) ]
         , fileBodyVariables = fromList []
         , filePackage = "21c24cd1-73fa-4970-8a6a-bc570e55b91e"
         }

--- a/test/golden/file-package-with-variables-4.output.yaml
+++ b/test/golden/file-package-with-variables-4.output.yaml
@@ -2,7 +2,7 @@ captures: |-
   [ Just
       FlatfileCapture
         { fileAbsoluteUrl = Just "https://datausa.io/api/data"
-        , fileVariables = fromList [ ( "b" , "data" ) , ( "a" , "api" ) ]
+        , fileVariables = fromList [ ( "a" , "api" ) , ( "b" , "data" ) ]
         , fileBodyVariables = fromList []
         , filePackage = "a1b331fa-1539-49e5-bdc4-dc8a48e586d1"
         }

--- a/test/golden/python-test-hash.output.body
+++ b/test/golden/python-test-hash.output.body
@@ -1,4 +1,4 @@
 <!DOCTYPE html><html><body><h1>numpy</h1>
-<a href="/simple/numpy/numpy-1.3.0.tar.gz#md5=68b329da9893e34099c7d8ad5cb9c940" data-gpg-sig="true">numpy-1.3.0.tar.gz</a><br>
 <a href="/simple/numpy/numpy-1.4.0.tar.gz#md5=60b725f10c9c85c70d97880dfe8191b3" data-requires-python=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*">numpy-1.4.0.tar.gz</a><br>
+<a href="/simple/numpy/numpy-1.3.0.tar.gz#md5=68b329da9893e34099c7d8ad5cb9c940" data-gpg-sig="true">numpy-1.3.0.tar.gz</a><br>
 </body></html>

--- a/test/golden/python-test-hash.output.yaml
+++ b/test/golden/python-test-hash.output.yaml
@@ -10,5 +10,5 @@ captures: |-
 headers:
   Content-Length: '351'
   Content-Type: text/html
-  Etag: '"poRjCQOfzSLEnMunwDeaf9iLsReZf61anTfTPU2nUEg="'
+  Etag: '"Ke3QIXFtz6ocFNhBv4K6o6-9R2TNGCiQlQnRObDQzgE="'
 status: 200

--- a/test/golden/python-test-package.output.body
+++ b/test/golden/python-test-package.output.body
@@ -1,4 +1,4 @@
 <!DOCTYPE html><html><body><h1>numpy</h1>
-<a href="/simple/numpy/numpy-1.3.0.tar.gz">numpy-1.3.0.tar.gz</a><br>
 <a href="/simple/numpy/numpy-1.4.0.tar.gz">numpy-1.4.0.tar.gz</a><br>
+<a href="/simple/numpy/numpy-1.3.0.tar.gz">numpy-1.3.0.tar.gz</a><br>
 </body></html>

--- a/test/golden/python-test-package.output.yaml
+++ b/test/golden/python-test-package.output.yaml
@@ -10,5 +10,5 @@ captures: |-
 headers:
   Content-Length: '196'
   Content-Type: text/html
-  Etag: '"nKXJKw6bVHghW5Egg1iiVvuSBLklJQSE0o9KKqNJllU="'
+  Etag: '"9q2MNUfAp5nrX5LWsYxHc7rr_SETJbyUtWch6qyCflA="'
 status: 200

--- a/test/golden/re-file-package-test-1.output.yaml
+++ b/test/golden/re-file-package-test-1.output.yaml
@@ -2,7 +2,7 @@ captures: |-
   [ Just
       FlatfileCapture
         { fileAbsoluteUrl = Just "https://datausa.io/api/data"
-        , fileVariables = fromList [ ( "b" , "data" ) , ( "a" , "api" ) ]
+        , fileVariables = fromList [ ( "a" , "api" ) , ( "b" , "data" ) ]
         , fileBodyVariables = fromList []
         , filePackage = "a1b331fa-1539-49e5-bdc4-dc8a48e586d1"
         }


### PR DESCRIPTION
## Summary

This changes the Docker/OCI proxy path without changing the existing Docker/containerd redirect path.

The gateway now handles upstream redirects explicitly when a request is already on `proxyTo`:

- Registry API redirects whose `Location` is still under `/v2` are followed inside the gateway. This covers backing registries like `cr.l5d.io` redirecting registry API requests to `ghcr.io` without exposing that cross-registry auth hop to clients.
- Non-registry redirects are passed back to clients. This is the signed blob/CDN redirect path, e.g. GHCR returning `pkg-containers.githubusercontent.com`.
- Redirect response bodies are not read, and redirect `Content-Length` is still stripped before responding.
- The upstream response timeout is 60s. Concurrent clients like Podman can issue many blob requests at once, and GHCR sometimes takes more than the old 10s budget to produce all signed redirects.

## What Changed

- Kept the existing Docker/containerd redirect branch in `Scarf.Gateway.Rule.Docker`.
- Kept `always-proxy` and Basic auth requests on the proxy path, as before.
- For other/non-redirecting clients that already use the proxy path, made proxying follow registry API redirects internally and pass signed blob/CDN redirects back to the client.
- Made `gatewayModifyProxyDomain` request-aware so production can choose cache-vs-backing-registry behavior by request/client. This matters for Scarf's pull-through cache: if the modifier rewrites all registry traffic to a Scarf cache, blob redirects will still point at cache infrastructure.
- Updated Docker unit tests so Docker-looking user agents continue to receive the old direct `307 Location: https://...` redirect, while CRI-O-style proxied requests exercise the new redirect passthrough path.
- Updated the Docker bandwidth README caveat to describe proxying the registry API while passing upstream blob redirects through.
- Aligned `cabal.project` with the CI workflow's GHC 9.4.4.
- Fixed a GHC 9.4 compile issue by qualifying `List.foldl'` in `URLTemplate`.
- Accepted current golden outputs for deterministic map/link ordering and related ETag expectations under the CI compiler path.

## Validation

Local checks:

- `git diff --check`
- `direnv exec . cabal test all` passed: 99/99 tests.

I could not run local `treefmt` because this machine's Nix dev shell currently fails while building the repo's `ghcid` derivation with a cycle error. The changed files compile in the test suite.

End-to-end pull/copy matrix against the local gateway with both Linear APP-15626 examples from the earlier validation pass:

| Client | Version / env | `linkerd/controller:stable-2.14.10` | `scarf-sh/scarf-postgres-exporter:latest` |
| --- | --- | --- | --- |
| Docker | 28.5.2, fresh Docker-in-Docker daemon | Pass | Pass |
| Podman | 5.8.2, privileged container, `vfs` storage | Pass | Pass |
| Buildah | 1.43.1, privileged container, `vfs` storage | Pass | Pass |
| Skopeo | 1.14.0, `skopeo copy` to `dir:` | Pass | Pass |
| Crane | 0.21.5, `crane pull --insecure` | Pass | Pass |
| ORAS | 1.3.0, `oras copy --to-oci-layout` | Pass | Pass |
| containerd / ctr | containerd 2.2.1, Ubuntu 24.04 container | Pass | Pass |
| nerdctl | 2.3.0, containerd container with `hosts.toml` | Pass | Pass |
| CRI-O / crictl | CRI-O 1.35.0 + crictl 1.35.0 via Nix | Pass native arm64 | Pass in amd64 CRI-O container |

CRI-O caveat: the Postgres exporter image does not publish a `linux/arm64/v8` manifest, and `crictl pull` has no platform override. Native arm64 CRI-O therefore fails before layer download with "no image found in image index for architecture arm64"; the same image passes with CRI-O running as `linux/amd64`.

Blob audit from the gateway validation log:

- 167 `GET /v2/.../blobs/...` requests observed.
- All 167 returned `307` from the gateway.
- No `GET /v2/.../blobs/...` returned `200`, `500`, or an error span.

That validates that, for these examples and clients, blob bodies were not downloaded through Scarf. The client received upstream signed blob redirects instead.

## Production Follow-Up

Production wrapper-level Docker Hub cache rewrites are handled in scarf-sh/repo#10114. That follow-up is scoped to avoid changing the main Docker/containerd route: Docker and containerd keep their existing behavior, while non-Docker/containerd proxy clients stop being sent through Scarf's Docker Hub pull-through cache.

Together, this gateway PR plus scarf-sh/repo#10114 let non-Docker/containerd proxy clients receive upstream blob redirects without going through Scarf's pull-through cache. That reduces cache usage, but it does not fully retire the cache while Docker/containerd can still route through it.